### PR TITLE
Update Flexigift.json

### DIFF
--- a/api/Flexigift.json
+++ b/api/Flexigift.json
@@ -32,27 +32,38 @@
   "gift_cards": [
     {
       "card_id": "hanes-gc-001",
+      "user_id": "user001",
       "issuer": "Hanes",
       "balance": 50.00,
       "expiry_date": "2025-12-31"
     },
     {
       "card_id": "nike-gc-002",
+      "user_id": "user001",
       "issuer": "Nike",
       "balance": 100.00,
       "expiry_date": "2024-11-30"
     },
     {
       "card_id": "starbucks-gc-003",
+      "user_id": "user002",
       "issuer": "Starbucks",
       "balance": 25.00,
       "expiry_date": "2024-06-30"
     },
     {
       "card_id": "gap-gc-004",
+      "user_id": "user003",
       "issuer": "Gap",
       "balance": 75.00,
       "expiry_date": "2025-05-15"
+    },
+    {
+      "card_id": "hanes-gc-001",
+      "user_id": "user004",
+      "issuer": "Hanes",
+      "balance": 50.00,
+      "expiry_date": "2025-12-31"
     }
   ],
   "products": [


### PR DESCRIPTION
I found an error in the JSON schema that we were using ... gift cards were not associated with a specific user_id, so tracking a specific user's cards and balances was not possible. I've updated the JSON file to include user_id's associated with each gift card.